### PR TITLE
feat(overview-panel): add panel that displays summarized data of a user's transactions

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -22,6 +22,7 @@
         "axios": "^1.6.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-google-charts": "^4.0.1",
         "react-router-dom": "^6.20.0",
         "react-scripts": "5.0.1",
         "web-vitals": "^2.1.4"
@@ -14997,6 +14998,15 @@
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
+    },
+    "node_modules/react-google-charts": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/react-google-charts/-/react-google-charts-4.0.1.tgz",
+      "integrity": "sha512-V/hcMcNuBgD5w49BYTUDye+bUKaPmsU5vy/9W/Nj2xEeGn+6/AuH9IvBkbDcNBsY00cV9OeexdmgfI5RFHgsXQ==",
+      "peerDependencies": {
+        "react": ">=16.3.0",
+        "react-dom": ">=16.3.0"
+      }
     },
     "node_modules/react-is": {
       "version": "17.0.2",

--- a/client/package.json
+++ b/client/package.json
@@ -18,6 +18,7 @@
     "axios": "^1.6.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-google-charts": "^4.0.1",
     "react-router-dom": "^6.20.0",
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4"

--- a/client/src/components/overview_panel/GroupRow.js
+++ b/client/src/components/overview_panel/GroupRow.js
@@ -1,0 +1,5 @@
+import { Box } from '@mui/material';
+
+export default function GroupRow({ groupTitle, amount }) {
+    return <Box>{groupTitle} — ${amount}</Box>
+}

--- a/client/src/components/overview_panel/OverviewChart.js
+++ b/client/src/components/overview_panel/OverviewChart.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import Chart from 'react-google-charts';
+import { Box } from '@mui/material';
+
+export default function OverviewChart({ groupList }) {
+    
+    const formatGroups = () => {
+        const formatedGroups = [];
+
+        for (let key in groupList) {
+            formatedGroups.push([key, groupList[key]]);
+        }
+
+        return formatedGroups;
+    }
+
+    const data = [
+        ['Group', 'Amount'],
+        ...formatGroups()
+    ];
+
+    const options = {
+        pieHole: 0.5,
+        chartArea: {width: '100%'},
+        legend: {position: 'bottom'},
+    };
+
+    return (
+        <Box>
+            <Chart
+                width={'100%'}
+                height={'400px'}
+                style={{marginTop: '-50px', zIndex: '-1'}}
+                chartType="PieChart"
+                loader={<Box>Loading Chart</Box>}
+                data={data}
+                options={options}
+            />
+        </Box>
+    );
+};

--- a/client/src/components/overview_panel/OverviewPanel.js
+++ b/client/src/components/overview_panel/OverviewPanel.js
@@ -2,6 +2,7 @@ import { Box, Button, Typography } from "@mui/material";
 import useTransactions from "../../hooks/useTransactions";
 import { useEffect, useState } from "react";
 import GroupRow from "./GroupRow";
+import OverviewChart from "./OverviewChart";
 
 
 export default function OverviewPanel() {
@@ -58,8 +59,13 @@ export default function OverviewPanel() {
     const groupList = getSortedGroupList();
 
     return (
-        <Box>
-            <Typography variant='h5'>Overview</Typography>
+        <Box sx={{
+            display: 'flex',
+            flexDirection: 'column'
+        }}>
+            <Typography variant='h5' style={{zIndex: '1'}}>Overview</Typography>
+
+            <OverviewChart groupList={groupList} />
 
             <Box>
                 <Button variant={transactionType === 'Expense' ? 'outlined' : ''} onClick={() => setTransactionType('Expense')}>Expense</Button>

--- a/client/src/components/overview_panel/OverviewPanel.js
+++ b/client/src/components/overview_panel/OverviewPanel.js
@@ -45,7 +45,17 @@ export default function OverviewPanel() {
         return sortedGroups;
     }
 
-    const groupList = Object.keys(groupedCategories[1][transactionType]).length === 0 ? groupCategories()[1][transactionType] : groupedCategories[1][transactionType];
+    const getSortedGroupList = () => {
+        let list = Object.keys(groupedCategories[1][transactionType]).length === 0 ? groupCategories()[1][transactionType] : groupedCategories[1][transactionType];
+        const sortedList = {};
+        const sortedKeys = Object.keys(list).sort((prev, curr) => prev === 'Other' ? 1 : curr === 'Other' ? -1 :  prev === curr ? 0 : prev < curr ? -1 : 1)
+        
+        sortedKeys.forEach(key => sortedList[key] = list[key]);
+
+        return sortedList;
+    }
+
+    const groupList = getSortedGroupList();
 
     return (
         <Box>
@@ -56,7 +66,7 @@ export default function OverviewPanel() {
                 <Button variant={transactionType === 'Income' ? 'outlined' : ''} onClick={() => setTransactionType('Income')}>Income</Button>
             </Box>
 
-            {Object.keys(groupList).sort((prev, curr) => prev === 'Other' ? 1 : curr === 'Other' ? -1 :  prev === curr ? 0 : prev < curr ? -1 : 1).map(key => {
+            {Object.keys(groupList).map(key => {
                 return (<GroupRow key={key} groupTitle={key} amount={groupList[key]} />)
             })}
         </Box>

--- a/client/src/components/overview_panel/OverviewPanel.js
+++ b/client/src/components/overview_panel/OverviewPanel.js
@@ -1,11 +1,64 @@
-import { Box, Typography } from "@mui/material";
+import { Box, Button, Typography } from "@mui/material";
+import useTransactions from "../../hooks/useTransactions";
+import { useEffect, useState } from "react";
+import GroupRow from "./GroupRow";
 
 
 export default function OverviewPanel() {
+    const { transactions } = useTransactions();
+    const [groupedCategories, setGroupedCategories] = useState([{Expense: {}, Income: {}}, {Expense: {}, Income: {}}]);
+    const [transactionType, setTransactionType] = useState('Expense');
+    
+    useEffect(() => {
+        setGroupedCategories(groupCategories());
+    }, [transactions]);
+
+    const groupCategories = () => {
+        const sortedGroups = transactions.reduce(([groups, totalAmounts], curr) => {
+            const newGroups = groups[curr.type];
+            const newTotalAmounts = totalAmounts[curr.type];
+
+            if (!curr.category) {
+                if (newGroups['Other']) {
+                    newGroups['Other'].push(curr);
+                    newTotalAmounts['Other'] += curr.amount;
+                } else {
+                    newGroups['Other'] = [curr];
+                    newTotalAmounts['Other'] = curr.amount;
+                }
+            }
+            else if (newGroups[curr.category]) {
+                newGroups[curr.category].push(curr);
+                newTotalAmounts[curr.category] += curr.amount;
+            }
+            else {
+                newGroups[curr.category] = [curr];
+                newTotalAmounts[curr.category] = curr.amount;
+            }
+
+            groups[curr.type] = newGroups;
+            totalAmounts[curr.type] = newTotalAmounts;
+
+            return [groups, totalAmounts];
+        }, [{Expense: {}, Income: {}}, {Expense: {}, Income: {}}]);
+
+        return sortedGroups;
+    }
+
+    const groupList = Object.keys(groupedCategories[1][transactionType]).length === 0 ? groupCategories()[1][transactionType] : groupedCategories[1][transactionType];
 
     return (
         <Box>
             <Typography variant='h5'>Overview</Typography>
+
+            <Box>
+                <Button variant={transactionType === 'Expense' ? 'outlined' : ''} onClick={() => setTransactionType('Expense')}>Expense</Button>
+                <Button variant={transactionType === 'Income' ? 'outlined' : ''} onClick={() => setTransactionType('Income')}>Income</Button>
+            </Box>
+
+            {Object.keys(groupList).sort((prev, curr) => prev === 'Other' ? 1 : curr === 'Other' ? -1 :  prev === curr ? 0 : prev < curr ? -1 : 1).map(key => {
+                return (<GroupRow key={key} groupTitle={key} amount={groupList[key]} />)
+            })}
         </Box>
     )
 }

--- a/client/src/components/overview_panel/OverviewPanel.js
+++ b/client/src/components/overview_panel/OverviewPanel.js
@@ -1,0 +1,11 @@
+import { Box, Typography } from "@mui/material";
+
+
+export default function OverviewPanel() {
+
+    return (
+        <Box>
+            <Typography variant='h5'>Overview</Typography>
+        </Box>
+    )
+}

--- a/client/src/components/transactions/TransactionPage.js
+++ b/client/src/components/transactions/TransactionPage.js
@@ -5,7 +5,8 @@ import useLogout from '../../hooks/useLogout';
 import useTransactions from '../../hooks/useTransactions';
 import useSortTransactions from '../../hooks/useSortTransactions';
 import TransactionTableContainer from './TransactionTableContainer';
-import { Box, Button } from '@mui/material';
+import { Button, Grid } from '@mui/material';
+import OverviewPanel from '../overview_panel/OverviewPanel';
 
 export default function TransactionPage() {
     const axiosPrivate = useAxiosPrivate();
@@ -34,9 +35,16 @@ export default function TransactionPage() {
     }, []);
 
     return (
-        <Box>
-            <Button onClick={handleLogout} sx={{marginTop: '5px'}}>Logout</Button>
-            <TransactionTableContainer />
-        </Box>
+        <Grid container sx={{padding: '1rem'}}>
+            <Grid item xs={12}> 
+                <Button onClick={handleLogout}>Logout</Button>
+            </Grid>
+            <Grid item xs={9.5}>
+                <TransactionTableContainer />
+            </Grid>
+            <Grid item>
+                <OverviewPanel />
+            </Grid>
+        </Grid>
     );
 }

--- a/client/src/components/transactions/TransactionPage.js
+++ b/client/src/components/transactions/TransactionPage.js
@@ -2,11 +2,9 @@ import { useState, useEffect } from 'react';
 import useAxiosPrivate from '../../hooks/useAxiosPrivate';
 import { Link, useNavigate, useLocation } from 'react-router-dom';
 import useLogout from '../../hooks/useLogout';
-import TransactionForm from './TransactionForm';
 import useTransactions from '../../hooks/useTransactions';
-import TransactionTable from './TransactionTable';
-import useOpenModal from '../../hooks/useOpenModal';
 import useSortTransactions from '../../hooks/useSortTransactions';
+import TransactionTableContainer from './TransactionTableContainer';
 
 export default function TransactionPage() {
     const axiosPrivate = useAxiosPrivate();
@@ -14,7 +12,6 @@ export default function TransactionPage() {
     const location = useLocation();
     const logout = useLogout();
     const { setTransactions } = useTransactions();
-    const openModal = useOpenModal();
     const sortTransactions = useSortTransactions();
 
     const getTransactions = async () => {
@@ -38,10 +35,7 @@ export default function TransactionPage() {
     return (
         <div>
             <button href='' onClick={handleLogout} style={{marginTop: '5px'}}>Logout</button>
-            <h1>Transactions</h1>
-            <TransactionTable />
-            <button onClick={() => openModal(<TransactionForm />)}>Add Transaction</button>
-            
+            <TransactionTableContainer />
         </div>
     );
 }

--- a/client/src/components/transactions/TransactionPage.js
+++ b/client/src/components/transactions/TransactionPage.js
@@ -5,6 +5,7 @@ import useLogout from '../../hooks/useLogout';
 import useTransactions from '../../hooks/useTransactions';
 import useSortTransactions from '../../hooks/useSortTransactions';
 import TransactionTableContainer from './TransactionTableContainer';
+import { Box, Button } from '@mui/material';
 
 export default function TransactionPage() {
     const axiosPrivate = useAxiosPrivate();
@@ -33,9 +34,9 @@ export default function TransactionPage() {
     }, []);
 
     return (
-        <div>
-            <button href='' onClick={handleLogout} style={{marginTop: '5px'}}>Logout</button>
+        <Box>
+            <Button onClick={handleLogout} sx={{marginTop: '5px'}}>Logout</Button>
             <TransactionTableContainer />
-        </div>
+        </Box>
     );
 }

--- a/client/src/components/transactions/TransactionPage.js
+++ b/client/src/components/transactions/TransactionPage.js
@@ -42,7 +42,7 @@ export default function TransactionPage() {
             <Grid item xs={9.5}>
                 <TransactionTableContainer />
             </Grid>
-            <Grid item>
+            <Grid item xs={2.5}>
                 <OverviewPanel />
             </Grid>
         </Grid>

--- a/client/src/components/transactions/TransactionTableContainer.js
+++ b/client/src/components/transactions/TransactionTableContainer.js
@@ -1,4 +1,4 @@
-import { Box } from "@mui/material";
+import { Box, Button, Typography } from "@mui/material";
 import TransactionTable from "./TransactionTable";
 import TransactionForm from "./TransactionForm";
 import useOpenModal from "../../hooks/useOpenModal";
@@ -8,9 +8,9 @@ export default function TransactionTableContainer() {
 
     return (
         <Box>
-            <h1>Transactions</h1>
+            <Typography variant='h4'>Transactions</Typography>
             <TransactionTable />
-            <button onClick={() => openModal(<TransactionForm />)}>Add Transaction</button>
+            <Button variant='outlined' onClick={() => openModal(<TransactionForm />)}>Add Transaction</Button>
         </Box>
     )
 }

--- a/client/src/components/transactions/TransactionTableContainer.js
+++ b/client/src/components/transactions/TransactionTableContainer.js
@@ -1,0 +1,16 @@
+import { Box } from "@mui/material";
+import TransactionTable from "./TransactionTable";
+import TransactionForm from "./TransactionForm";
+import useOpenModal from "../../hooks/useOpenModal";
+
+export default function TransactionTableContainer() {
+    const openModal = useOpenModal();
+
+    return (
+        <Box>
+            <h1>Transactions</h1>
+            <TransactionTable />
+            <button onClick={() => openModal(<TransactionForm />)}>Add Transaction</button>
+        </Box>
+    )
+}


### PR DESCRIPTION
Added a side panel that displays a summary of the user's transactions and a pie chart that represents that data, grouped by categories. The pie chart is created using the react-google-charts library that was added to the app's dependencies. 

This panel allows the user to get a better understanding of how much expenses and income went into each of the categories. 

For future development, we could add more customization to the panel so the user can group by more than just categories and can specify a time range of what transactions should be included in the summary.