### PR TITLE
feat(transactions): change formats of transaction data displayed to the user

### DIFF
--- a/client/src/components/transactions/TransactionDetailModal.js
+++ b/client/src/components/transactions/TransactionDetailModal.js
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react";
 import useAxiosPrivate from "../../hooks/useAxiosPrivate";
 import useTransactions from "../../hooks/useTransactions";
 import useModal from "../../hooks/useModal";
+import useFormatDate from "../../hooks/useFormatDate";
 
 const containerStyles = {
     width: '50%',
@@ -20,6 +21,7 @@ export default function TransactionDetailModal({ transaction }) {
     const axiosPrivate = useAxiosPrivate();
     const { setTransactions } = useTransactions();
     const { modalOpen, setModalOpen } = useModal();
+    const formatDate = useFormatDate();
 
     useEffect(() => {
         if (!modalOpen)
@@ -57,7 +59,7 @@ export default function TransactionDetailModal({ transaction }) {
                     <Typography variant='overline' sx={{fontWeight: 'bold', fontSize: '1rem', mr: '1rem'}}>
                         Date
                     </Typography>
-                    {transaction.date}
+                    {formatDate(transaction.date, true)}
                 </Grid>
 
                 <Grid item xs={6}>

--- a/client/src/components/transactions/TransactionEntry.js
+++ b/client/src/components/transactions/TransactionEntry.js
@@ -16,9 +16,9 @@ export default function TransactionEntry({ transaction }) {
             <TableCell component="th" scope="row"  sx={{fontWeight: 'bold'}}>
                 $ {transaction.amount.toFixed(2)}
             </TableCell>
-            <TableCell>{transaction.date}</TableCell>
+            <TableCell>{transaction.date.split('T')[0]}</TableCell>
             <TableCell>{transaction.type}</TableCell>
-            <TableCell>{transaction.category}</TableCell>
+            <TableCell>{transaction.category || '—'}</TableCell>
             <TableCell>
                 {transaction.description.length > 70 ? `${transaction.description.substring(0, 70)}...` : transaction.description}
             </TableCell>

--- a/client/src/components/transactions/TransactionEntry.js
+++ b/client/src/components/transactions/TransactionEntry.js
@@ -1,10 +1,12 @@
 import { TableRow, TableCell } from "@mui/material";
 import useOpenModal from "../../hooks/useOpenModal";
 import TransactionDetailModal from './TransactionDetailModal';
+import useFormatDate from "../../hooks/useFormatDate";
 
 export default function TransactionEntry({ transaction }) {
     const openModal = useOpenModal();
-    
+    const formatDate = useFormatDate();
+
     return (
         <TableRow
             sx={{ 
@@ -16,7 +18,7 @@ export default function TransactionEntry({ transaction }) {
             <TableCell component="th" scope="row"  sx={{fontWeight: 'bold'}}>
                 $ {transaction.amount.toFixed(2)}
             </TableCell>
-            <TableCell>{transaction.date.split('T')[0]}</TableCell>
+            <TableCell>{formatDate(transaction.date, false)}</TableCell>
             <TableCell>{transaction.type}</TableCell>
             <TableCell>{transaction.category || '—'}</TableCell>
             <TableCell>

--- a/client/src/components/transactions/TransactionEntry.js
+++ b/client/src/components/transactions/TransactionEntry.js
@@ -19,7 +19,9 @@ export default function TransactionEntry({ transaction }) {
             <TableCell>{transaction.date}</TableCell>
             <TableCell>{transaction.type}</TableCell>
             <TableCell>{transaction.category}</TableCell>
-            <TableCell>{transaction.description}</TableCell>
+            <TableCell>
+                {transaction.description.length > 70 ? `${transaction.description.substring(0, 70)}...` : transaction.description}
+            </TableCell>
         </TableRow>
     );
 }

--- a/client/src/hooks/useFormatDate.js
+++ b/client/src/hooks/useFormatDate.js
@@ -1,0 +1,15 @@
+
+export default function useFormatDate() {
+    const formatDate = (date, longFormat) => {
+        const options = longFormat ? 
+            { weekday: 'short', year: 'numeric', month: 'long', day: 'numeric' }
+            :
+            { year: 'numeric', month: 'short', day: 'numeric' }
+
+        const [year, month, day] = date.split('T')[0].split('-');
+        date = new Date(`${month}-${day}-${year}`);
+        return date.toLocaleDateString('en-us', options);
+    }
+
+    return formatDate;
+}


### PR DESCRIPTION
Changed the way that dates, long descriptions, and empty categories are displayed to the user.

These changes make the data more readable and allow the layout of the transaction data table to be more consistent.

The dates have been changed from their default date format (2024-01-01T00:00:00.000Z) to a more readable format (Jan 1, 2024 and Mon, January 1, 2024). Descriptions displayed in the transaction data table have been capped at 70 characters and will display an ellipsis (...) after 70 characters if the description length is over that amount. Empty categories (transactions where a category was not provided by the user) now display an em dash (—) as a placeholder in the transaction date table.